### PR TITLE
Upgrade project from .NET 9 to .NET 10 (LTS)

### DIFF
--- a/src/FooBar.API/FooBar.API.csproj
+++ b/src/FooBar.API/FooBar.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -9,12 +9,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
-		<PackageReference Include="Scalar.AspNetCore" Version="2.1.11" />
-		<PackageReference Include="Serilog" Version="4.2.0" />
-		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+		<PackageReference Include="Scalar.AspNetCore" Version="2.11.0" />
+		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.203",
+    "version": "10.0.203",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `TargetFramework` from `net9.0` to `net10.0`
- Updates SDK pin in `global.json` to `10.0.203`
- Updates all NuGet dependencies to their .NET 10 compatible versions
- Removes explicit `Microsoft.Extensions.Logging` reference (now a transitive dependency in .NET 10)

## Package updates
| Package | Before | After |
|---|---|---|
| Microsoft.AspNetCore.OpenApi | 9.0.4 | 10.0.7 |
| Serilog.AspNetCore | 9.0.0 | 10.0.0 |
| Serilog | 4.2.0 | 4.3.1 |
| Scalar.AspNetCore | 2.1.11 | 2.11.0 |
| FluentValidation.DependencyInjectionExtensions | 11.11.0 | 12.1.1 |

## Test plan
- [ ] Build passes with `dotnet build`
- [ ] Verify app starts and OpenAPI/Scalar UI loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)